### PR TITLE
feat: default auth to get-github-auth-token's

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,14 @@ Only publicly visible emails can be retrieved.
 
 ### Options
 
-`auth` must be provided as an option or via `process.env.GH_TOKEN`.
+`auth` is retrieved with [`get-github-auth-token`](https://github.com/JoshuaKGoldberg/get-github-auth-token), which defaults to `process.env.GH_TOKEN`, or failing that, [`gh auth token`](https://cli.github.com/manual/gh_auth_token).
+If neither is available then an auth token must be provided as an option.
 
-| Option         | Type     | Description                        | Default                |
-| -------------- | -------- | ---------------------------------- | ---------------------- |
-| `auth`         | `string` | Auth token for Octokit REST calls. | `process.env.GH_TOKEN` |
-| `historyLimit` | `number` | How many public events to look at. | `500`                  |
-| `username`     | `string` | GitHub user to check emails of.    |                        |
+| Option         | Type     | Description                        | Default                                      |
+| -------------- | -------- | ---------------------------------- | -------------------------------------------- |
+| `auth`         | `string` | Auth token for Octokit REST calls. | `process.env.GH_TOKEN` or `$(gh auth token)` |
+| `historyLimit` | `number` | How many public events to look at. | `500`                                        |
+| `username`     | `string` | GitHub user to check emails of.    |                                              |
 
 ```ts
 await getGitHubUsernameEmails({

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"*": "prettier --ignore-unknown --write"
 	},
 	"dependencies": {
+		"get-github-auth-token": "^0.1.0",
 		"octokit": "^4.0.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      get-github-auth-token:
+        specifier: ^0.1.0
+        version: 0.1.0
       octokit:
         specifier: ^4.0.0
         version: 4.0.2
@@ -2175,6 +2178,10 @@ packages:
 
   get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+
+  get-github-auth-token@0.1.0:
+    resolution: {integrity: sha512-ENm+A39AV0X4+Ls1jiCvmqx+C8hSYTv4d5hV9Ks+EL+gx9a0P9pYYpRE1k2ExwRT3EFQabGXF1Rkdp5FIsLkiw==}
+    engines: {node: '>=18'}
 
   get-intrinsic@1.2.4:
     resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
@@ -6492,6 +6499,8 @@ snapshots:
   get-east-asian-width@1.2.0: {}
 
   get-func-name@2.0.2: {}
+
+  get-github-auth-token@0.1.0: {}
 
   get-intrinsic@1.2.4:
     dependencies:

--- a/src/getGitHubUsernameEmails.test.ts
+++ b/src/getGitHubUsernameEmails.test.ts
@@ -2,6 +2,14 @@ import { describe, expect, it, vi } from "vitest";
 
 import { getGitHubUsernameEmails } from "./getGitHubUsernameEmails.js";
 
+const mockGetGitHubAuthToken = vi.fn();
+
+vi.mock("get-github-auth-token", () => ({
+	get getGitHubAuthToken() {
+		return mockGetGitHubAuthToken;
+	},
+}));
+
 vi.mock("octokit", () => ({
 	Octokit: class MockOctokit {
 		request = vi.fn();
@@ -19,28 +27,37 @@ vi.mock("./getEventsEmails.js", () => ({
 const username = "abc123";
 
 describe("getGitHubUsernameEmails", () => {
-	it("throws an error when no auth is provided or available on process.env", async () => {
-		process.env.GH_TOKEN = "";
+	it("throws an error when no auth is provided or available", async () => {
+		mockGetGitHubAuthToken.mockResolvedValue({
+			succeeded: false,
+			token: "gho_def456",
+		});
 
 		await expect(
 			async () => await getGitHubUsernameEmails({ username }),
 		).rejects.toMatchInlineSnapshot(
-			`[Error: Please provide an auth token (process.env.GH_TOKEN).]`,
+			`[Error: Please provide an auth token (process.env.GH_TOKEN) or log in with the GitHub CLI (gh).]`,
 		);
 	});
 
 	it("throws an error an empty auth is provided", async () => {
-		process.env.GH_TOKEN = "gho_def456";
+		mockGetGitHubAuthToken.mockResolvedValue({
+			succeeded: true,
+			token: "gho_def456",
+		});
 
 		await expect(
 			async () => await getGitHubUsernameEmails({ auth: "", username }),
 		).rejects.toMatchInlineSnapshot(
-			`[Error: Please provide an auth token (process.env.GH_TOKEN).]`,
+			`[Error: Invalid auth provided: an empty string ('').]`,
 		);
 	});
 
-	it("returns account and events emails when auth is valid", async () => {
-		process.env.GH_TOKEN = "gho_def456";
+	it("returns account and events emails when getGitHubAuthToken auth is valid", async () => {
+		mockGetGitHubAuthToken.mockResolvedValue({
+			succeeded: true,
+			token: "gho_def456",
+		});
 
 		const actual = await getGitHubUsernameEmails({ username });
 

--- a/src/getGitHubUsernameEmails.ts
+++ b/src/getGitHubUsernameEmails.ts
@@ -1,3 +1,4 @@
+import { getGitHubAuthToken } from "get-github-auth-token";
 import { Octokit } from "octokit";
 
 import { getAccountEmail } from "./getAccountEmail.js";
@@ -14,14 +15,29 @@ export interface GitHubUsernameEmails {
 	events: EmailsToNames;
 }
 
+async function retrieveAuth(provided: string | undefined) {
+	if (provided === "") {
+		throw new Error("Invalid auth provided: an empty string ('').");
+	}
+
+	const auth = await getGitHubAuthToken();
+	if (auth.succeeded) {
+		return auth.token;
+	}
+
+	throw new Error(
+		"Please provide an auth token (process.env.GH_TOKEN) or log in with the GitHub CLI (gh).",
+		{
+			cause: auth.error,
+		},
+	);
+}
+
 export async function getGitHubUsernameEmails({
-	auth,
+	auth: providedAuth,
 	...rawOptions
 }: GitHubUsernameEmailsOptions): Promise<GitHubUsernameEmails> {
-	auth ??= process.env.GH_TOKEN;
-	if (!auth) {
-		throw new Error(`Please provide an auth token (process.env.GH_TOKEN).`);
-	}
+	const auth = await retrieveAuth(providedAuth);
 
 	const octokit = new Octokit({ auth });
 	const options = { ...defaultOptions, ...rawOptions };


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #320
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/github-username-to-emails/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/github-username-to-emails/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Swaps in `get-github-auth-token` instead of the existing logic. Yay.

💖 
